### PR TITLE
Fixed broken link

### DIFF
--- a/meetups/Meetup_Best_Practices.md
+++ b/meetups/Meetup_Best_Practices.md
@@ -1,4 +1,4 @@
 ## Meetup Best Practices
 
 Moved to [CNCF
-Meetups](https://github.com/cncf/meetups/blob/master/Meetup_Best_Practices.md).
+Meetups](https://github.com/cncf/meetups/).


### PR DESCRIPTION
Change from https://github.com/cncf/meetups/blob/master/Meetup_Best_Practices.md to https://github.com/cncf/meetups/ so links continue working.