### PR TITLE
Ricardo stepping down for 2023

### DIFF
--- a/EMERITUS.md
+++ b/EMERITUS.md
@@ -18,3 +18,4 @@ You'll still be listed as an ambassador emeritus on the CNCF page and are entitl
 * Hunter Nield
 * Taylor Dolezal, CNCF
 * [David Flanagan](@rawkode)
+* Ricardo Katz, VMware


### PR DESCRIPTION
Signed-off-by: Ricardo Katz <rikatz@users.noreply.github.com>

As the program is being revamped and needs re-application, I don't plan to reapply. I don't have the time I wish I had, and the Ambassador profile that is required for "public relations" with the community :)

Instead, I would like to give some room for people more engaged in the overall Cloud Native Community, willing that more people in Latin America are selected for the new program so that we can get proper attention from CNCF to the south hemisphere community. 

Thank you all for the opportunity and the partnership.