### PR TITLE
docs: clarify reimbursement instructions

### DIFF
--- a/2.0/Reimbursements_Meetup.md
+++ b/2.0/Reimbursements_Meetup.md
@@ -15,8 +15,8 @@
 -	Please expense receipts after you have spent the money.
 -	Email the expense report (which includes the receipts) to ambassador-support@cncf.io.
 	-	For Meetup food/beverage reimbursements, please include a link to that month’s Meetup page in your email.
-	-	If you are based in the US, please provide your mailing address or ACH info in the email.
-	-	If you are not based in the US, please include your wire info in the email.
+	-	If you are based in the US, please provide your mailing address or ACH info in the expense report.
+	-	If you are not based in the US, please include your wire info in the expense report.
 -	We try to reimburse you in less than 2 weeks.
 
 #### **What Can You Expense**


### PR DESCRIPTION
Clarifying that I think the mailing address/ACH/wire instructions should be in the expense report (which is attached to an email), and not the email body since earlier in the doc it says:
> Please do not send banking/wire details in the body of an email.