### PR TITLE
Fix: website name & URL link

### DIFF
--- a/2.0/Reimbursements_Meetup.md
+++ b/2.0/Reimbursements_Meetup.md
@@ -1,7 +1,7 @@
-**CNCF Ambassadors can be reimbursed for up to $150 per month for Meetup-related expenses as long as the Ambassador is using and hosting events on [Community.cncf.io](https://community.cncf.io/), including food, beverages, and swag from the online store. Exceptions for higher amounts or special items are granted on a case-by-case basis (see below).**
+**CNCF Ambassadors can be reimbursed for up to $150 per month for Meetup-related expenses as long as the Ambassador is using and hosting events on [community.cncf.io](https://community.cncf.io/), including food, beverages, and swag from the online store. Exceptions for higher amounts or special items are granted on a case-by-case basis (see below).**
 
 #### Reimbursement Instructions:
-1.	Create an account in the recommended expense report software [expensify.com](expensify.com) (if you already have a expense report software you can use that software if you prefer)
+1.	Create an account in the recommended expense report software [expensify.com](https://expensify.com) (if you already have a expense report software you can use that software if you prefer)
 2.	Create a report through expensify.com and attach receipts to the full report. Export as a PDF
    	-	For Meetup food/beverage reimbursements, please include a link to that month’s Meetup page in your email.
  	-	Please expense receipts after you have spent the money.


### PR DESCRIPTION
- `Community.cncf.io` => `community.cncf.io`
- `expensify.com` will direct to `https://github.com/cncf/ambassadors/blob/main/2.0/expensify.com`. This is 
an unexpected link.