### PR TITLE
Fixing readme with correct paths

### DIFF
--- a/2.0/Profile.md
+++ b/2.0/Profile.md
@@ -58,11 +58,11 @@ And here is an example entry:
 
 ## Images
 
-Upload your headshot image to the `/images/` directory with a filename made up of your name.  Images should be at least 500x500px, 72dpi, and should be in JPG format with file size less than 100kB.
+Upload your headshot image to the [/images/](https://github.com/cncf/people/tree/main/images) directory with a filename made up of your name.  Images should be at least 500x500px, 72dpi, and should be in JPG format with file size less than 100kB.
 
 ## Team Management
 
-Also within this repo is a YAML file used by our [automation tooling](https://github.com/electron/sheriff) to help us manage access to resources for teams. This tooling takes advantage of data in [people.json](people.json) such as the `email` and `slack_id` fields. This will allow us to add maintainers to different properties only using their GitHub handle.
+Also within this repo is a YAML file used by our [automation tooling](https://github.com/electron/sheriff) to help us manage access to resources for teams. This tooling takes advantage of data in [people.json](https://github.com/cncf/people/blob/main/people.json) such as the `email` and `slack_id` fields. This will allow us to add maintainers to different properties only using their GitHub handle.
 
 - To find your Slack ID for the CNCF slack, please follow this [handy guide](https://moshfeu.medium.com/how-to-find-my-member-id-in-slack-workspace-d4bba942e38c)
 


### PR DESCRIPTION
Seems like the repo with the docs and the "people" has been split, fixing docs to point the `images/` directory and `people.json` file to the correct repo